### PR TITLE
Allow detection of root (last) fragment in plan:

### DIFF
--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -40,6 +40,7 @@ std::string executionStrategyToString(ExecutionStrategy strategy);
 /// Contains some information on how to execute the fragment of a plan.
 /// Used to construct Task.
 struct PlanFragment {
+  int prestoId{0};
   /// Top level (root) Plan Node.
   std::shared_ptr<const core::PlanNode> planNode;
   ExecutionStrategy executionStrategy{ExecutionStrategy::kUngrouped};

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2781,7 +2781,8 @@ PartitionedOutputNode::PartitionedOutputNode(
     PartitionFunctionSpecPtr partitionFunctionSpec,
     RowTypePtr outputType,
     VectorSerde::Kind serdeKind,
-    PlanNodePtr source)
+    PlanNodePtr source,
+    bool isRootFragment)
     : PlanNode(id),
       kind_(kind),
       sources_{{std::move(source)}},
@@ -2790,7 +2791,8 @@ PartitionedOutputNode::PartitionedOutputNode(
       replicateNullsAndAny_(replicateNullsAndAny),
       partitionFunctionSpec_(std::move(partitionFunctionSpec)),
       serdeKind_(serdeKind),
-      outputType_(std::move(outputType)) {
+      outputType_(std::move(outputType)),
+      isRootFragment_(isRootFragment) {
   VELOX_USER_CHECK_GT(numPartitions_, 0);
   if (numPartitions_ == 1) {
     VELOX_USER_CHECK(
@@ -2815,7 +2817,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::broadcast(
     int numPartitions,
     RowTypePtr outputType,
     VectorSerde::Kind serdeKind,
-    PlanNodePtr source) {
+    PlanNodePtr source,
+    bool isRootFragment) {
   std::vector<TypedExprPtr> noKeys;
   return std::make_shared<PartitionedOutputNode>(
       id,
@@ -2826,7 +2829,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::broadcast(
       std::make_shared<GatherPartitionFunctionSpec>(),
       std::move(outputType),
       serdeKind,
-      std::move(source));
+      std::move(source),
+      isRootFragment);
 }
 
 // static
@@ -2834,7 +2838,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::arbitrary(
     const PlanNodeId& id,
     RowTypePtr outputType,
     VectorSerde::Kind serdeKind,
-    PlanNodePtr source) {
+    PlanNodePtr source,
+    bool isRootFragment) {
   std::vector<TypedExprPtr> noKeys;
   return std::make_shared<PartitionedOutputNode>(
       id,
@@ -2845,7 +2850,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::arbitrary(
       std::make_shared<GatherPartitionFunctionSpec>(),
       std::move(outputType),
       serdeKind,
-      std::move(source));
+      std::move(source),
+      isRootFragment);
 }
 
 // static
@@ -2853,7 +2859,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::single(
     const PlanNodeId& id,
     RowTypePtr outputType,
     VectorSerde::Kind serdeKind,
-    PlanNodePtr source) {
+    PlanNodePtr source,
+    bool isRootFragment) {
   std::vector<TypedExprPtr> noKeys;
   return std::make_shared<PartitionedOutputNode>(
       id,
@@ -2864,7 +2871,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::single(
       std::make_shared<GatherPartitionFunctionSpec>(),
       std::move(outputType),
       serdeKind,
-      std::move(source));
+      std::move(source),
+      isRootFragment);
 }
 
 void EnforceSingleRowNode::addDetails(std::stringstream& /* stream */) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2532,26 +2532,30 @@ class PartitionedOutputNode : public PlanNode {
       PartitionFunctionSpecPtr partitionFunctionSpec,
       RowTypePtr outputType,
       VectorSerde::Kind serdeKind,
-      PlanNodePtr source);
+      PlanNodePtr source,
+      bool isRootFragment = false);
 
   static std::shared_ptr<PartitionedOutputNode> broadcast(
       const PlanNodeId& id,
       int numPartitions,
       RowTypePtr outputType,
       VectorSerde::Kind serdeKind,
-      PlanNodePtr source);
+      PlanNodePtr source,
+      bool isRootFragment = false);
 
   static std::shared_ptr<PartitionedOutputNode> arbitrary(
       const PlanNodeId& id,
       RowTypePtr outputType,
       VectorSerde::Kind serdeKind,
-      PlanNodePtr source);
+      PlanNodePtr source,
+      bool isRootFragment = false);
 
   static std::shared_ptr<PartitionedOutputNode> single(
       const PlanNodeId& id,
       RowTypePtr outputType,
       VectorSerde::Kind VectorSerde,
-      PlanNodePtr source);
+      PlanNodePtr source,
+      bool isRootFragment = false);
 
   class Builder {
    public:
@@ -2568,6 +2572,7 @@ class PartitionedOutputNode : public PlanNode {
       serdeKind_ = other.serdeKind();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
+      isRootFragment_ = other.isRootFragment();
     }
 
     Builder& id(PlanNodeId id) {
@@ -2647,7 +2652,8 @@ class PartitionedOutputNode : public PlanNode {
           partitionFunctionSpec_.value(),
           outputType_.value(),
           serdeKind_.value(),
-          source_.value());
+          source_.value(),
+          isRootFragment_.value_or(false));
     }
 
    private:
@@ -2660,7 +2666,12 @@ class PartitionedOutputNode : public PlanNode {
     std::optional<RowTypePtr> outputType_;
     std::optional<VectorSerde::Kind> serdeKind_;
     std::optional<PlanNodePtr> source_;
+    std::optional<bool> isRootFragment_;
   };
+
+  const bool isRootFragment() const {
+    return isRootFragment_;
+  }
 
   const RowTypePtr& outputType() const override {
     return outputType_;
@@ -2741,6 +2752,7 @@ class PartitionedOutputNode : public PlanNode {
   const PartitionFunctionSpecPtr partitionFunctionSpec_;
   const VectorSerde::Kind serdeKind_;
   const RowTypePtr outputType_;
+  const bool isRootFragment_;
 };
 
 using PartitionedOutputNodePtr = std::shared_ptr<const PartitionedOutputNode>;


### PR DESCRIPTION
If last plan fragment contains a Partitioned Output node, then this plan fragment mustn't be converted to Cudf, otherwise the coordinator won't receive the final results.