### PR TITLE
Fix close issue in CudfExchangeClient/Server.

### DIFF
--- a/velox/experimental/cudf-exchange/Communicator.cpp
+++ b/velox/experimental/cudf-exchange/Communicator.cpp
@@ -115,11 +115,17 @@ void Communicator::registerCommElement(std::shared_ptr<CommElement> comms) {
 }
 
 void Communicator::addToWorkQueue(std::shared_ptr<CommElement> comms) {
+  if (!comms) {
+    return;
+  }
   workQueue_.push(comms);
 }
 
 void Communicator::unregister(std::shared_ptr<CommElement> comms) {
   std::lock_guard<std::mutex> lock(elemMutex_);
+  if (!comms) {
+    return;
+  }
   workQueue_.erase(comms);
   elements_.erase(comms);
 }

--- a/velox/experimental/cudf-exchange/CudfExchangeClient.cpp
+++ b/velox/experimental/cudf-exchange/CudfExchangeClient.cpp
@@ -21,7 +21,6 @@
 namespace facebook::velox::cudf_exchange {
 
 void CudfExchangeClient::addRemoteTaskId(const std::string& remoteTaskId) {
-  std::vector<std::shared_ptr<CudfExchangeSource>> requestSpecs;
   std::shared_ptr<CudfExchangeSource> toClose;
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
@@ -107,7 +106,6 @@ folly::F14FastMap<std::string, RuntimeMetric> CudfExchangeClient::stats()
 std::unique_ptr<cudf::packed_columns>
 CudfExchangeClient::next(int consumerId, bool* atEnd, ContinueFuture* future) {
   VLOG(3) << "CudfExchangeClient::next called for task " << taskId_;
-  std::vector<std::shared_ptr<CudfExchangeSource>> requestSpecs;
   std::unique_ptr<cudf::packed_columns> columns;
   ContinuePromise stalePromise = ContinuePromise::makeEmpty();
   {

--- a/velox/experimental/cudf-exchange/CudfExchangeServer.cpp
+++ b/velox/experimental/cudf-exchange/CudfExchangeServer.cpp
@@ -91,18 +91,21 @@ void CudfExchangeServer::process() {
       // do
       break;
     case ServerState::Done:
-      // unregister.
-      communicator_->unregister(getSelfPtr());
       close();
       break;
   };
 }
 
 void CudfExchangeServer::close() {
-  VLOG(3) << "Close CudfExchangeServer to remote " << partitionKey_.toString()
-          << ".";
+  bool expected = false;
+  bool desired = true;  
+  if (!closed_.compare_exchange_strong(expected, desired)) {
+    return; // already closed.
+  }
+  VLOG(3) << "Close CudfExchangeServer to remote " << partitionKey_.toString();
   if (endpointRef_) {
     endpointRef_->removeCommElem(getSelfPtr());
+    endpointRef_ = nullptr;
   }
   communicator_->unregister(getSelfPtr());
 }

--- a/velox/experimental/cudf-exchange/CudfExchangeServer.h
+++ b/velox/experimental/cudf-exchange/CudfExchangeServer.h
@@ -105,6 +105,7 @@ class CudfExchangeServer
   std::atomic<ServerState> state_;
   std::unique_ptr<cudf::packed_columns> dataPtr_{nullptr};
   std::recursive_mutex dataMutex_; // mutex for above ptr.
+  std::atomic<bool> closed_{false};
 
   uint32_t sequenceNumber_{0};
 

--- a/velox/experimental/cudf-exchange/CudfExchangeSource.cpp
+++ b/velox/experimental/cudf-exchange/CudfExchangeSource.cpp
@@ -107,12 +107,17 @@ void CudfExchangeSource::process() {
 }
 
 void CudfExchangeSource::close() {
+  bool expected = false;
+  bool desired = true;  
+  if (!closed_.compare_exchange_strong(expected, desired)) {
+    return; // already closed.
+  }
   VLOG(1) << "CudfExchangeSource::close called.";
   VLOG(1) << fmt::format("closing task: {}", partitionKey_.toString());
-  closed_.store(true);
   VLOG(3) << "Close receiver to remote " << partitionKey_.toString() << ".";
   if (endpointRef_) {
     endpointRef_->removeCommElem(getSelfPtr());
+    endpointRef_=nullptr;
   }
   communicator_->unregister(getSelfPtr());
 }
@@ -156,14 +161,19 @@ PartitionKey CudfExchangeSource::extractTaskAndDestinationId(
 }
 
 std::shared_ptr<CudfExchangeSource> CudfExchangeSource::getSelfPtr() {
-  return shared_from_this();
+  std::shared_ptr<CudfExchangeSource> ptr;
+  try {
+    ptr = shared_from_this();
+  } catch(std::bad_weak_ptr &exp) {
+    ptr = nullptr;
+  }
+  return ptr;
 }
 
 void CudfExchangeSource::enqueue(
     std::unique_ptr<cudf::packed_columns> columns,
     MetadataMsg& metadata) {
   std::vector<velox::ContinuePromise> queuePromises;
-  velox::VeloxPromise<ExchangeSource::Response> requestPromise;
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
 
@@ -300,10 +310,10 @@ void CudfExchangeSource::onMetadata(
       // It seems that all data has been transferred
       atEnd_ = true;
       // enqueue a nullpointer to mark the end for this source.
-      VLOG(3) << "There is no more data to transfer";
-      enqueue(nullptr, ptr->metadata);
+      VLOG(3) << "There is no more data to transfer for " << toString();
       setState(ReceiverState::Done);
       communicator_->addToWorkQueue(getSelfPtr());
+      enqueue(nullptr, ptr->metadata);
       // jump out of this function.
       return;
     }


### PR DESCRIPTION
Close of CudfExchangeSource is called when the CudfExchange operator is called but also when the UCXX endpoint is closed or when the CudfExchangeSource receives a metadata message that indicates the end of data.
Since this is done in different threads, close must be thread safe. This is achieved using an atomic flag and the test-and-set method.