### PR TITLE
Collect cudf queue metrics in taskStats.

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2575,22 +2575,26 @@ void Task::maybeRemoveFromOutputBufferManager() {
       // Capture output buffer stats before deleting the buffer.
       {
         std::lock_guard<std::timed_mutex> l(mutex_);
-        if (!taskStats_.outputBufferStats.has_value()) {
-          taskStats_.outputBufferStats = bufferManager->stats(taskId_);
+        auto optStats = bufferManager->stats(taskId_);
+        if (!taskStats_.outputBufferStats.has_value() && optStats.has_value()) {
+          taskStats_.outputBufferStats = optStats;
         }
       }
       bufferManager->removeTask(taskId_);
     }
 #ifdef VELOX_ENABLE_CUDF
-    // Do the same for the Cudf Queue Manager
-    auto queueMgr = facebook::velox::cudf_exchange::CudfOutputQueueManager::
-        getInstanceRef();
-    // TODO: Add stats, call to queueMgr->stats(taskId_) doesn't exist yet.
-    // std::lock_guard<std::timed_mutex> l(mutex_);
-    // if (!taskStats_.outputBufferStats.has_value()) {
-    //   taskStats_.outputBufferStats = queueMgr->stats(taskId_);
-    // }
-    queueMgr->removeTask(taskId_);
+      // Capture output queue stats before deleting the queue.
+      auto queueMgr = facebook::velox::cudf_exchange::CudfOutputQueueManager::
+          getInstanceRef();
+      // Capture output buffer stats before deleting the buffer.
+      {
+        std::lock_guard<std::timed_mutex> l(mutex_);
+        auto optStats = queueMgr->stats(taskId_);
+        if (optStats.has_value() && optStats.value().totalPagesSent > 0) {
+          taskStats_.outputBufferStats = optStats;
+        }
+      }
+      queueMgr->removeTask(taskId_);
 #endif
   }
 }


### PR DESCRIPTION
This needs some reworking and is a temporary solution to integrate the metrics. What needs to be improved:
* VELOX_ENABLE_CUDF implies that CUDF exchange is also enabled, which may or may not be the case
* Rather than always creating and initializing buffers/queues in both the classic Velox OutputBufferManager and the CUDF Queue Manager, the task should only create what it really needs and uses.