### PR TITLE
Add blocking / flow control to CudfPartitionedOutput.

### DIFF
--- a/velox/experimental/cudf-exchange/CudfOutputQueueManager.cpp
+++ b/velox/experimental/cudf-exchange/CudfOutputQueueManager.cpp
@@ -138,7 +138,6 @@ std::shared_ptr<CudfOutputQueue> CudfOutputQueueManager::getQueue(
   std::optional<exec::OutputBuffer::Stats> CudfOutputQueueManager::stats(const std::string& taskId) {
     auto queue = getQueueIfExists(taskId);
     if (queue != nullptr) {
-      VLOG(1) << "-=-=- CudfOutputQueueManager::stats called";
       return queue->stats();
     }
     return std::nullopt;

--- a/velox/experimental/cudf-exchange/CudfPartitionedOutput.cpp
+++ b/velox/experimental/cudf-exchange/CudfPartitionedOutput.cpp
@@ -85,9 +85,11 @@ void CudfPartitionedOutput::addInput(RowVectorPtr input) {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK(cudfVector, "Input must be a CudfVector");
+  VELOX_CHECK(!future_.valid() || future_.hasValue(), "addInput with outstanding future!");
   auto stream = cudfVector->stream();
 
   cudf::table_view tableView;
+  bool blocked;
   if (remap_.empty()) {
     // input and output column order is the same.
     tableView = cudfVector->getTableView();
@@ -98,9 +100,9 @@ void CudfPartitionedOutput::addInput(RowVectorPtr input) {
 
   if (numPartitions_ > 1) {
     if (partitionKeyIndices_.size() > 0 || spec_ == "gather") {
-      hashPartition(tableView, cudfVector->stream());
+      blocked = hashPartition(tableView, cudfVector->stream());
     } else {
-      equalPartition(tableView, cudfVector->stream());
+      blocked = equalPartition(tableView, cudfVector->stream());
     }
   } else {
     // Single partition case. No need to hash, assume queue zero
@@ -115,30 +117,35 @@ void CudfPartitionedOutput::addInput(RowVectorPtr input) {
     std::unique_ptr<cudf::packed_columns> packedColsPtr =
         std::make_unique<cudf::packed_columns>(
             std::move(packedCols.metadata), std::move(packedCols.gpu_data));    
-    bool res = sharedQueueManager()->enqueue(
+    blocked = sharedQueueManager()->enqueue(
         this->taskId(),
         0,
         std::move(packedColsPtr),
         tableView.num_rows(),
-        nullptr);
-    // FIXME Will return true if queue is full: ignore for now
+        &future_);
+
     VLOG(3) << "enqueued cudf vector with "
-            << tableView.num_rows() << " rows";
+            << tableView.num_rows() << " rows into partition 0 for task " << this->taskId();
   }
   // record the statistics.
   {
     auto lockedStats = stats_.wlock();
     lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
   }
+  blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer 
+                : exec::BlockingReason::kNotBlocked;        
 }
 
 exec::BlockingReason CudfPartitionedOutput::isBlocked(ContinueFuture* future) {
-  // As we currently are ignoring running out of memory we are never blocked
+  if (blockingReason_ != exec::BlockingReason::kNotBlocked) {
+    *future = std::move(future_);
+    blockingReason_ = exec::BlockingReason::kNotBlocked;
+    return exec::BlockingReason::kWaitForConsumer;
+  }
   return exec::BlockingReason::kNotBlocked;
 }
 
 RowVectorPtr CudfPartitionedOutput::getOutput() {
-  VLOG(2) << "CudfPartitionedOutput::getOutput()";
   if (finished_) {
     return nullptr;
   }
@@ -151,7 +158,6 @@ RowVectorPtr CudfPartitionedOutput::getOutput() {
 }
 
 bool CudfPartitionedOutput::isFinished() {
-  VLOG(2) << "CudfPartitionedOutput::isFinished(): " << finished_;
   return finished_;
 }
 
@@ -215,7 +221,7 @@ void CudfPartitionedOutput::initPartitionKeys(
   }
 }
 
-void CudfPartitionedOutput::hashPartition(cudf::table_view tableView, rmm::cuda_stream_view stream) {
+bool CudfPartitionedOutput::hashPartition(cudf::table_view tableView, rmm::cuda_stream_view stream) {
   VLOG(3) << "Hashing and partitioning into " << numPartitions_ << " chunks";
 
   // Use cudf hash partitioning
@@ -238,11 +244,11 @@ void CudfPartitionedOutput::hashPartition(cudf::table_view tableView, rmm::cuda_
   // Erase first element since it's always 0 and we don't need it.
   partitionOffsets.erase(partitionOffsets.begin());
 
-  splitAndEnqueue(
+  return splitAndEnqueue(
       partitionedTable->view(), partitionOffsets, stream);
 }
 
-void CudfPartitionedOutput::equalPartition(cudf::table_view tableView, rmm::cuda_stream_view stream) {
+bool CudfPartitionedOutput::equalPartition(cudf::table_view tableView, rmm::cuda_stream_view stream) {
   VLOG(3) << "Splitting into " << numPartitions_ << " chunks";
   std::vector<cudf::size_type> offsets;
   cudf::size_type size = tableView.num_rows();
@@ -250,17 +256,19 @@ void CudfPartitionedOutput::equalPartition(cudf::table_view tableView, rmm::cuda
     cudf::size_type idx = size / (numPartitions_ / (double)i);
     offsets.push_back(idx);
   }
-  splitAndEnqueue(tableView, offsets, stream);
+  return splitAndEnqueue(tableView, offsets, stream);
 }
 
-void CudfPartitionedOutput::splitAndEnqueue(
+bool CudfPartitionedOutput::splitAndEnqueue(
     cudf::table_view tableView,
     std::vector<cudf::size_type> offsets,
     rmm::cuda_stream_view stream) {
+  bool blocked = false;
   auto contiguousTables = cudf::contiguous_split(tableView, offsets, stream);
 
   VELOX_CHECK_EQ(
       offsets.size() + 1, numPartitions_, "mismatch in numPartitions_");
+  ContinueFuture* future = &future_;
   for (int i = 0; i < numPartitions_; ++i) {
     auto const& partitionTable = contiguousTables[i];
     auto packedColsPtr = std::make_unique<cudf::packed_columns>(
@@ -274,16 +282,19 @@ void CudfPartitionedOutput::splitAndEnqueue(
 
     // enqueue partition data on Cudf Output Buffer
     VLOG(3) << "Enqueued " << partitionTable.table.num_rows()
-            << " rows into partition " << i;
-    bool res = sharedQueueManager()->enqueue(
+            << " rows into partition " << i << " for task " << this->taskId();
+    blocked = blocked || sharedQueueManager()->enqueue(
         this->taskId(),
         i,
         std::move(packedColsPtr),
         partitionTable.table.num_rows(),
-        nullptr);
-
-    // FIXME Will return false if queue is full: ignore for now
+        future);
+    if (blocked) {
+      // The future_ is set for the first destination queue that blocks.
+      future = nullptr; 
+    }
   }
+  return blocked;
 }
 
 } // namespace facebook::velox::cudf_exchange

--- a/velox/experimental/cudf-exchange/CudfPartitionedOutput.h
+++ b/velox/experimental/cudf-exchange/CudfPartitionedOutput.h
@@ -66,18 +66,20 @@ class CudfPartitionedOutput : public exec::Operator,
       const std::shared_ptr<const core::PartitionedOutputNode>& planNode);
 
   // Partitions the cudf table view using the partition keys and a hash
-  // function using the given stream.
-  void hashPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
+  // function using the given stream. Returns true if any of the queues are blocked.
+  bool hashPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
 
   // Splits the cudf table view into equal sizes. This is used when
   // RoundRobin partitioning is requested but round robin on a
   // row-by-row basis is not meaningful for cudf exchange.
-  void equalPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
+  // Returns true if any of the queues are blocked.
+  bool equalPartition(cudf::table_view tableView, rmm::cuda_stream_view stream);
 
   // Splits the table along the given offsets and enqueues each offset
   // to the corresponding partition, i.e. first split to the partition 0,
   // second split to partition 1 etc.
-  void splitAndEnqueue(
+  // Returns true if any of the queues are blocked.
+  bool splitAndEnqueue(
       cudf::table_view tableView,
       std::vector<cudf::size_type> offsets,
       rmm::cuda_stream_view stream);
@@ -85,8 +87,9 @@ class CudfPartitionedOutput : public exec::Operator,
   const std::weak_ptr<CudfOutputQueueManager> queueManager_;
   std::vector<column_index_t> partitionKeyIndices_;
   const size_t numPartitions_;
-  std::vector<exec::BlockingReason> blockingReasons_;
-  std::vector<ContinueFuture> futures_;
+  
+  exec::BlockingReason blockingReason_;
+  ContinueFuture future_;
 
   bool finished_{false};
   std::string spec_;

--- a/velox/experimental/cudf-exchange/CudfQueues.cpp
+++ b/velox/experimental/cudf-exchange/CudfQueues.cpp
@@ -21,7 +21,6 @@ void CudfDestinationQueue::Stats::recordEnqueue(
     const cudf::packed_columns* data) {
   if (data != nullptr) {
     bytesQueued += data->gpu_data->size();
-    rowsQueued++; // FIXME: Add #rows as input param
     packedColumnsQueued++;
   }
 }
@@ -29,8 +28,14 @@ void CudfDestinationQueue::Stats::recordEnqueue(
 void CudfDestinationQueue::Stats::recordDequeue(
     const cudf::packed_columns* data) {
   if (data != nullptr) {
-    bytesSent += data->gpu_data->size();
-    rowsSent++; // FIXME: Add #rows as input param
+    const int64_t size = data->gpu_data->size();
+
+    bytesQueued -= size;
+    VELOX_DCHECK_GE(bytesBuffered, 0, "bytesQueued must be non-negative");
+    --packedColumnsQueued;
+    VELOX_DCHECK_GE(packedColumnsQueued, 0, "packedColumnsQueued must be non-negative");
+
+    bytesSent += size;
     packedColumnsSent++;
   }
 }
@@ -135,6 +140,10 @@ CudfOutputQueue::CudfOutputQueue(
     uint32_t numDestinations,
     uint32_t numDrivers)
     : task_(task), numDrivers_(numDrivers) {
+  if (task_) {
+    maxSize_ = task_->queryCtx()->queryConfig().maxOutputBufferSize();
+    continueSize_ = (maxSize_ * kContinuePct) / 100;
+  } // else: maxSize_ and continueSize_ will be set once the task is created and initialize called.
   // create a queue for each destination.
   queues_.reserve(numDestinations);
   for (int i = 0; i < numDestinations; ++i) {
@@ -155,6 +164,8 @@ bool CudfOutputQueue::initialize(
   }
   task_ = task;
   numDrivers_ = numDrivers;
+  maxSize_ = task_->queryCtx()->queryConfig().maxOutputBufferSize();
+  continueSize_ = (maxSize_ * kContinuePct) / 100;
   // create additional queues if there are more destinations.
   for (int i = queues_.size(); i < numDestinations; ++i) {
     // create the destination queues inside the vector using emplace_back.
@@ -202,7 +213,11 @@ bool CudfOutputQueue::enqueue(
       updateStatsWithEnqueuedLocked(numBytes, numRows);
     }
 
-    // FIXME: Add a check whether queue exceeds its limit.
+    if (queuedBytes_ >= maxSize_ && future) {
+      promises_.emplace_back("CudfOutputQueue::enqueue");
+      *future = promises_.back().getSemiFuture();
+      blocked = true;
+    }
   }
   // Now that data is enqueued, notify blocked readers (outside of mutex.)
 
@@ -216,6 +231,7 @@ void CudfOutputQueue::getData(
     int destination,
     CudfDataAvailableCallback notify) {
   CudfDestinationQueue::Data data;
+  std::vector<ContinuePromise> promises;    
   {
     std::lock_guard<std::mutex> l(mutex_);
     // If the queue doesn't exist yet, create an empty queue to store
@@ -233,17 +249,23 @@ void CudfOutputQueue::getData(
         std::unique_ptr<cudf::packed_columns> data,
         std::vector<int64_t> remainingBytes
       ) {
+        std::vector<ContinuePromise> promises;        
         auto bytes = data ? data->gpu_data->size() : 0L;
         notify(std::move(data), std::move(remainingBytes));
         if (bytes > 0L) {
           std::lock_guard<std::mutex> l(mutex_);
-          this->updateStatsWithFreedLocked(bytes);
+          this->updateStatsWithFreedLocked(bytes, 1L, promises);
+        }
+        // outside of lock:
+        // wake up any producers that are waiting for queue to become less full.
+        for (auto& promise : promises) {
+          promise.setValue();
         }
       });
       if (data.data) {
         // This implies data.immediate and no notify upcall will be done.
         // Need to update the stats here.
-        updateStatsWithFreedLocked(data.data->gpu_data->size());
+        updateStatsWithFreedLocked(data.data->gpu_data->size(), 1L, promises);
       }
     } else {
       data = CudfDestinationQueue::Data{nullptr, {}, true};
@@ -252,6 +274,10 @@ void CudfOutputQueue::getData(
   // outside lock: If we have data, then return it immediately.
   if (data.immediate) {
     notify(std::move(data.data), std::move(data.remainingBytes));
+  }
+  // wake up any producers that are waiting for queue to become less full.
+  for (auto& promise : promises) {
+    promise.setValue();
   }
 }
 
@@ -326,6 +352,7 @@ bool CudfOutputQueue::isFinishedLocked() {
 void CudfOutputQueue::deleteResults(int destination) {
   bool isFinished;
   CudfDataAvailable dataAvailable;
+  std::vector<ContinuePromise> promises;  
   {
     std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK_LT(destination, queues_.size());
@@ -334,6 +361,9 @@ void CudfOutputQueue::deleteResults(int destination) {
       VLOG(1) << "Extra delete received for destination " << destination;
       return;
     }
+    // remember destination queue fill stats
+    int64_t bytes = queue->stats().bytesQueued;
+    int64_t packedCols = queue->stats().packedColumnsQueued;
     queue->deleteResults();
     dataAvailable = queue->getAndClearNotify();
     queue->finish();
@@ -341,10 +371,16 @@ void CudfOutputQueue::deleteResults(int destination) {
     finishedQueueStats_[destination] = queues_[destination]->stats();
     queues_[destination] = nullptr;
     isFinished = isFinishedLocked();
+    // update CudfOutputQueue stats
+    updateStatsWithFreedLocked(bytes, packedCols, promises);
   }
 
   // Outside of mutex.
   dataAvailable.notify();
+  // wake up any producers that are waiting for queue to become less full.
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
 
   if (isFinished) {
     task_->setAllOutputConsumed();
@@ -419,7 +455,6 @@ exec::OutputBuffer::Stats CudfOutputQueue::stats() {
       getAverageQueueTimeMsLocked(),
       countTopQueues(queueStats, totalBytesSent_),
       { /* FIXME: transition queueStats to exec::DestinationBuffer::Stats */});
-  VLOG(3) << "-=-=- tb: " << totalBytesSent_ << " tr: " << totalRowsSent_ << " tc: " << totalPackedColumnsSent_;
   return stats;
 }
 
@@ -434,14 +469,20 @@ void CudfOutputQueue::updateStatsWithEnqueuedLocked(int64_t bytes, int64_t rows)
   totalPackedColumnsSent_++;
 }
 
-void CudfOutputQueue::updateStatsWithFreedLocked(int64_t bytes) {
+void CudfOutputQueue::updateStatsWithFreedLocked(int64_t bytes, int64_t numPackedCols, std::vector<ContinuePromise>& promises) {
   updateTotalQueuedBytesMsLocked();
 
   queuedBytes_ -= bytes;
-  queuedPackedColumns_--;
+  queuedPackedColumns_ -= numPackedCols;
 
   VELOX_CHECK_GE(queuedBytes_, 0);
   VELOX_CHECK_GE(queuedPackedColumns_, 0);
+
+  // Check whether queue is below low-water mark and return outstanding
+  // promises
+  if (queuedBytes_ <= continueSize_) {
+    promises = std::move(promises_);
+  }
 }
 
 void CudfOutputQueue::updateTotalQueuedBytesMsLocked() {

--- a/velox/experimental/cudf-exchange/CudfQueues.h
+++ b/velox/experimental/cudf-exchange/CudfQueues.h
@@ -61,12 +61,10 @@ class CudfDestinationQueue {
 
     // what has been queued
     int64_t bytesQueued{0};
-    int64_t rowsQueued{0};
     int64_t packedColumnsQueued{0};
 
     // what has been dequeued
     int64_t bytesSent{0};
-    int64_t rowsSent{0};
     int64_t packedColumnsSent{0};
   };
 
@@ -206,10 +204,17 @@ class CudfOutputQueue {
   exec::OutputBuffer::Stats stats();
 
  private:
+  // Percentage of maxSize below which a blocked producer should
+  // be unblocked.
+  static constexpr int32_t kContinuePct = 90;
+
   // Methods that update the statistics.
   void updateStatsWithEnqueuedLocked(int64_t bytes, int64_t rows);
 
-  void updateStatsWithFreedLocked(int64_t bytes);
+  // updates the counters and returns promises if the queuedBytes_ counter falls
+  // below the continueSize_ low water mark. These promises then need to be realized
+  // outside the lock.
+  void updateStatsWithFreedLocked(int64_t bytes, int64_t numPackedCols, std::vector<ContinuePromise>& promises);
 
   void updateTotalQueuedBytesMsLocked();
 
@@ -231,6 +236,13 @@ class CudfOutputQueue {
   // Reference to the task that owns this CudfQueue.
   std::shared_ptr<exec::Task> task_{nullptr};
 
+  /// If 'queuedBytes_' > 'maxSize_', each producer is blocked after adding
+  /// data.
+  uint64_t maxSize_;
+  // When 'queuedBytes_' goes below 'continueSize_', blocked producers are
+  // resumed.
+  uint64_t continueSize_;
+
   // Total number of drivers expected to produce results. This number will
   // decrease in the end of grouped execution, when we understand the real
   // number of producer drivers (depending on the number of split groups).
@@ -251,11 +263,13 @@ class CudfOutputQueue {
   // the queue is finished and deleted.
   std::vector<CudfDestinationQueue::Stats> finishedQueueStats_;
 
-
   // keep track of the number of drivers that have finished.
   uint32_t numFinished_{0};
 
   bool atEnd_ = false;
+
+  // promises when buffer reached capacity and blocked further enqueueing.
+  std::vector<ContinuePromise> promises_;
 
   // actual data in 'queues_'
   int64_t queuedBytes_{0};


### PR DESCRIPTION
This adds a simple flow control mechanism to the `CudfPartitionedOutput` operator. It works as follows:
- The configuration parameter `maxOutputBufferSize` determines whether data can be added to the set of `CudfDestinationQueue`s that make up the `CudfOutputQueue` or not.
- The operator returns "blocked" in `isBlocked()` when the queue size exceeds `maxSize_` and returns a future.
- When the `CudfExchangeServer` consumes from one of the destination queue such that the total size of the `CudfOutputQueue` falls below `kContinuePct`x`maxSize_`, then the promise associated with the above return future is fulfilled.

Low- and high-water mark are initialized in `CudfOutputQueue` and checked whenever data is added or removed from the underlying destination queues. The `CudfParittionedOutput` operator is given a boolean flag when enqueueing data that indicates whether the `CudfOutputQueue` is blocked or not. The logic to unblock the operator is done in the driver.