### PR TITLE
Fix flow-ctrl related bug in CudfPartitionedOutput.

### DIFF
--- a/velox/experimental/cudf-exchange/CudfExchangeServer.h
+++ b/velox/experimental/cudf-exchange/CudfExchangeServer.h
@@ -78,8 +78,6 @@ class CudfExchangeServer
   /// @param newState the new state of the CudfExchangeServer.
   void setState(ServerState newState) {
     state_.store(newState, std::memory_order_seq_cst);
-    VLOG(3) << "Task " << partitionKey_.toString()
-            << " setting to state: " << getStateAsString();
   }
 
   /// @brief Returns the state.

--- a/velox/experimental/cudf-exchange/CudfPartitionedOutput.cpp
+++ b/velox/experimental/cudf-exchange/CudfPartitionedOutput.cpp
@@ -123,9 +123,6 @@ void CudfPartitionedOutput::addInput(RowVectorPtr input) {
         std::move(packedColsPtr),
         tableView.num_rows(),
         &future_);
-
-    VLOG(3) << "enqueued cudf vector with "
-            << tableView.num_rows() << " rows into partition 0 for task " << this->taskId();
   }
   // record the statistics.
   {
@@ -133,7 +130,7 @@ void CudfPartitionedOutput::addInput(RowVectorPtr input) {
     lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
   }
   blockingReason_ = blocked ? exec::BlockingReason::kWaitForConsumer 
-                : exec::BlockingReason::kNotBlocked;        
+                : exec::BlockingReason::kNotBlocked;
 }
 
 exec::BlockingReason CudfPartitionedOutput::isBlocked(ContinueFuture* future) {
@@ -271,24 +268,23 @@ bool CudfPartitionedOutput::splitAndEnqueue(
   ContinueFuture* future = &future_;
   for (int i = 0; i < numPartitions_; ++i) {
     auto const& partitionTable = contiguousTables[i];
-    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
-        std::move(contiguousTables[i].data.metadata),
-        std::move(contiguousTables[i].data.gpu_data));
-
     if (partitionTable.table.num_rows() == 0) {
       // Skip empty partitions.
       continue;
     }
 
+    auto packedColsPtr = std::make_unique<cudf::packed_columns>(
+        std::move(contiguousTables[i].data.metadata),
+        std::move(contiguousTables[i].data.gpu_data));
+
     // enqueue partition data on Cudf Output Buffer
-    VLOG(3) << "Enqueued " << partitionTable.table.num_rows()
-            << " rows into partition " << i << " for task " << this->taskId();
-    blocked = blocked || sharedQueueManager()->enqueue(
+    bool tb = sharedQueueManager()->enqueue(
         this->taskId(),
         i,
         std::move(packedColsPtr),
         partitionTable.table.num_rows(),
         future);
+    blocked = tb || blocked;
     if (blocked) {
       // The future_ is set for the first destination queue that blocks.
       future = nullptr; 

--- a/velox/experimental/cudf-exchange/CudfQueues.cpp
+++ b/velox/experimental/cudf-exchange/CudfQueues.cpp
@@ -250,9 +250,9 @@ void CudfOutputQueue::getData(
         std::vector<int64_t> remainingBytes
       ) {
         std::vector<ContinuePromise> promises;        
-        auto bytes = data ? data->gpu_data->size() : 0L;
+        int64_t bytes = data ? data->gpu_data->size() : -1L;
         notify(std::move(data), std::move(remainingBytes));
-        if (bytes > 0L) {
+        if (bytes >= 0L) {
           std::lock_guard<std::mutex> l(mutex_);
           this->updateStatsWithFreedLocked(bytes, 1L, promises);
         }


### PR DESCRIPTION
When a split lead to a blocked queue, the subsequent splits where not enqueued any more. This PR fixes this.