### PR TITLE
Fix creation of exchange clients when multiple drivers are present.

### DIFF
--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -341,16 +341,17 @@ bool CompileState::compile() {
       } else {
         // Get or create the CudfExchangeClient, using parameters from the Velox
         // exchange client.
+        auto key = TaskPlanNodeKey(oper->taskId(), oper->planNodeId());
         auto clientIter =
-            cudfExchangeClientByPlanNode_.find(oper->planNodeId());
+            cudfExchangeClientByTaskAndPlanNode_.find(key);
         std::shared_ptr<CudfExchangeClient> client = nullptr;
-        if (clientIter == cudfExchangeClientByPlanNode_.end()) {
+        if (clientIter == cudfExchangeClientByTaskAndPlanNode_.end()) {
           // create new cudfExchangeClient
           std::shared_ptr<ExchangeClient> veloxExchangeClient =
               exchangeOp->exchangeClient_;
           client = createCudfExchangeClient(
+              oper->taskId(),
               oper->planNodeId(),
-              veloxExchangeClient->taskId_,
               veloxExchangeClient->destination_,
               veloxExchangeClient->numberOfConsumers_,
               veloxExchangeClient->executor_);
@@ -418,14 +419,15 @@ bool CompileState::compile() {
 }
 
 std::shared_ptr<CudfExchangeClient> CompileState::createCudfExchangeClient(
-    const core::PlanNodeId& planNodeId,
     const std::string& taskId,
+    const core::PlanNodeId& planNodeId,
     const int destination,
     const int32_t numberOfConsumers,
     folly::Executor* executor) {
   auto client = std::make_shared<CudfExchangeClient>(
       taskId, destination, numberOfConsumers, executor);
-  cudfExchangeClientByPlanNode_.emplace(planNodeId, client);
+  TaskPlanNodeKey key(taskId, planNodeId);
+  cudfExchangeClientByTaskAndPlanNode_.emplace(key, client);
   return client;
 }
 

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -33,6 +33,34 @@ namespace facebook::velox::cudf_velox {
 
 static const std::string kCudfAdapterName = "cuDF";
 
+struct TaskPlanNodeKey {
+  std::string taskId;
+  core::PlanNodeId planNodeId;
+
+  TaskPlanNodeKey(const std::string& tid, const core::PlanNodeId& pid)
+      : taskId(tid), planNodeId(pid) {}
+
+  // need equality operator for unordered map.
+  bool operator==(const TaskPlanNodeKey& other) const {
+    return taskId == other.taskId && planNodeId == other.planNodeId;
+  }
+
+  // Need a hash functor for the unordered map.
+  struct Hash {
+    std::size_t operator()(const TaskPlanNodeKey& key) const {
+      std::hash<std::string> hasher;
+      std::size_t h1 = hasher(key.taskId);
+      std::size_t h2 = hasher(key.planNodeId);
+      return h1 ^ (h2 << 1); // simple combination of the two hash functions.
+    }
+  };
+};
+
+static std::unordered_map<
+  TaskPlanNodeKey,
+  std::shared_ptr<cudf_exchange::CudfExchangeClient>,
+  TaskPlanNodeKey::Hash> cudfExchangeClientByTaskAndPlanNode_;
+
 class CompileState {
  public:
   CompileState(const exec::DriverFactory& driverFactory, exec::Driver& driver)
@@ -47,18 +75,14 @@ class CompileState {
   bool compile();
 
   std::shared_ptr<cudf_exchange::CudfExchangeClient> createCudfExchangeClient(
-      const core::PlanNodeId& planNodeId,
       const std::string& taskId,
+      const core::PlanNodeId& planNodeId,
       const int destination,
       const int32_t numberOfConsumers,
       folly::Executor* executor);
 
   const exec::DriverFactory& driverFactory_;
   exec::Driver& driver_;
-  std::unordered_map<
-      core::PlanNodeId,
-      std::shared_ptr<cudf_exchange::CudfExchangeClient>>
-      cudfExchangeClientByPlanNode_;
 };
 
 class CudfOptions {


### PR DESCRIPTION
With multiple drivers, multiple CudfExchangeClients per task have been created erroneously by the local planner.
The (temporary) fix is to introduce a global map from [TaskId + PlanNodeId] => CudfExchangeClient.
This needs to be cleaned up together with the other hooks for the CudfOutputQueue.

With this fix, not all the queries run with multiple drivers. These errors can be observed:
```
VeloxRuntimeError:  Operator::getOutput failed for [operator: CudfHashJoinProbe, plan node ID: 1686]:
CUDA error at: /gpfs/zc2/u/dnb/presto_zrl/presto-native-execution/_build/release/_deps/rmm-src/cpp/src/cuda_stream_view.cpp:56: 
cudaErrorIllegalAddress an illegal memory access was encountered
```
and
```
VeloxRuntimeError: numPartitions_ == 1 || partitionKeyIndices_.size() > 0 
```

The assumption is that these errors will be fixed by updating the Cudf operators.