### PR TITLE
Implement kArbitrary exchange mode for UCX

### DIFF
--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -235,6 +235,12 @@ void UcxOutputQueue::enqueue(
       totalRowsSent_ += numRows;
       totalPackedColumnsSent_++;
       success = true;
+    } else if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary) {
+      VELOX_CHECK_EQ(destination, 0, "Arbitrary uses destination 0");
+      enqueueArbitraryOutputLocked(
+          std::move(sharedData), dataAvailableCallbacks);
+      updateStatsWithEnqueuedLocked(numBytes, numRows);
+      success = true;
     } else {
       VELOX_CHECK_LT(destination, queues_.size());
       success = enqueuePartitionedOutputLocked(
@@ -280,6 +286,13 @@ void UcxOutputQueue::getData(int destination, UcxDataAvailableCallback notify) {
     // queue can be nullptr here if the task has terminated and results
     // have been removed. In this case, no data is returned.
     if (queue) {
+      // For arbitrary mode, pull from the shared buffer if the destination
+      // queue is empty. This ensures demand-driven distribution.
+      if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary &&
+          !arbitraryBuffer_.empty()) {
+        queue->enqueueBack(std::move(arbitraryBuffer_.front()));
+        arbitraryBuffer_.pop_front();
+      }
       // Capture weak_ptr instead of raw `this` to prevent use-after-free.
       // The callback fires outside the lock (from enqueue() or terminate()),
       // and concurrent removeTask() can destroy the UcxOutputQueue while
@@ -364,6 +377,24 @@ void UcxOutputQueue::checkIfDone(bool oneDriverFinished) {
               << " avgRowsPerChunk=" << avgRows
               << " totalBytes=" << totalBytesSent_;
     }
+    // For arbitrary, drain remaining shared pool to destination queues
+    // round-robin before sending end markers.
+    if (kind_ == core::PartitionedOutputNode::Kind::kArbitrary) {
+      int32_t bufferId = nextArbitraryLoadIndex_;
+      int32_t nullCount = 0;
+      while (!arbitraryBuffer_.empty()) {
+        auto* queue = queues_[bufferId].get();
+        if (queue != nullptr) {
+          queue->enqueueBack(std::move(arbitraryBuffer_.front()));
+          arbitraryBuffer_.pop_front();
+          nullCount = 0;
+        } else if (++nullCount >= queues_.size()) {
+          arbitraryBuffer_.clear();
+          break;
+        }
+        bufferId = (bufferId + 1) % queues_.size();
+      }
+    }
     for (auto& queue : queues_) {
       if (queue != nullptr) {
         queue->enqueueBack(nullptr);
@@ -411,6 +442,42 @@ void UcxOutputQueue::enqueueBroadcastOutputLocked(
   }
 }
 
+void UcxOutputQueue::enqueueArbitraryOutputLocked(
+    std::shared_ptr<cudf::packed_columns> data,
+    std::vector<UcxDataAvailable>& dataAvailableCbs) {
+  VELOX_DCHECK(dataAvailableCbs.empty());
+
+  arbitraryBuffer_.push_back(std::move(data));
+
+  // Distribute from the shared pool to destinations with waiting consumers,
+  // probing round-robin so no single destination starves.
+  int32_t bufferId = nextArbitraryLoadIndex_;
+  for (int32_t i = 0; i < queues_.size(); ++i) {
+    if (arbitraryBuffer_.empty()) {
+      break;
+    }
+    auto* queue = queues_[bufferId].get();
+    if (queue != nullptr) {
+      // getAndClearNotify returns the pending callback (if any) and clears
+      // it. When the destination queue is empty the returned data is null.
+      auto pending = queue->getAndClearNotify();
+      if (pending.callback) {
+        pending.data = std::move(arbitraryBuffer_.front());
+        arbitraryBuffer_.pop_front();
+        pending.remainingBytes.clear();
+        for (const auto& item : arbitraryBuffer_) {
+          if (item != nullptr) {
+            pending.remainingBytes.push_back(item->gpu_data->size());
+          }
+        }
+        dataAvailableCbs.push_back(std::move(pending));
+      }
+    }
+    bufferId = (bufferId + 1) % queues_.size();
+  }
+  nextArbitraryLoadIndex_ = bufferId;
+}
+
 bool UcxOutputQueue::isFinished() {
   std::lock_guard<std::mutex> l(mutex_);
   return isFinishedLocked();
@@ -419,6 +486,8 @@ bool UcxOutputQueue::isFinished() {
 bool UcxOutputQueue::isFinishedLocked() {
   // For broadcast, we can only be finished after receiving the no more
   // (destination) buffers signal, matching OutputBuffer::isFinishedLocked().
+  // For arbitrary, the coordinator lazily manages consumers and may never send
+  // noMoreBufferIds, so we only check that all queues have been consumed.
   if (kind_ == core::PartitionedOutputNode::Kind::kBroadcast &&
       !noMoreQueues_) {
     return false;
@@ -441,24 +510,25 @@ void UcxOutputQueue::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
     return;
   }
 
-  VELOX_CHECK_EQ(kind_, Kind::kBroadcast);
+  VELOX_CHECK(kind_ == Kind::kBroadcast || kind_ == Kind::kArbitrary);
   bool isFinished;
   {
     std::lock_guard<std::mutex> l(mutex_);
 
     if (numBuffers > queues_.size()) {
-      // Add new destination queues and backfill with broadcast data.
       int32_t numNewBuffers = numBuffers - queues_.size();
       queues_.reserve(numBuffers);
       for (int32_t i = 0; i < numNewBuffers; ++i) {
         auto buffer = std::make_unique<UcxDestinationQueue>();
-        for (const auto& data : dataToBroadcast_) {
-          buffer->enqueueBack(data);
-          // Account for backfilled data in queuedBytes_ so that dequeue
-          // decrements don't drive it negative.
-          queuedBytes_ += data->gpu_data->size();
-          queuedPackedColumns_++;
+        if (kind_ == Kind::kBroadcast) {
+          // Backfill new destinations with previously broadcast data.
+          for (const auto& data : dataToBroadcast_) {
+            buffer->enqueueBack(data);
+            queuedBytes_ += data->gpu_data->size();
+            queuedPackedColumns_++;
+          }
         }
+        // No backfill for arbitrary — new consumers only get future data.
         if (atEnd_) {
           buffer->enqueueBack(nullptr);
         }
@@ -529,6 +599,7 @@ void UcxOutputQueue::terminate() {
       LOG(WARNING) << "UcxOutputQueue::terminate() called while task "
                    << task_->taskId() << " is still running";
     }
+    arbitraryBuffer_.clear();
     // Fire all pending getData callbacks with nullptr to signal end-of-stream.
     // This handles the case where a producer task fails or is cancelled before
     // noMoreData() is called, preventing consumers from being orphaned.

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -267,6 +267,10 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
       std::shared_ptr<cudf::packed_columns> data,
       std::vector<UcxDataAvailable>& dataAvailableCbs);
 
+  void enqueueArbitraryOutputLocked(
+      std::shared_ptr<cudf::packed_columns> data,
+      std::vector<UcxDataAvailable>& dataAvailableCbs);
+
   // Reference to the task that owns this UcxQueue.
   std::shared_ptr<exec::Task> task_{nullptr};
 
@@ -282,6 +286,13 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   // For broadcast: stores data for late-arriving destinations that need
   // backfill. Cleared once noMoreQueues_ is set.
   std::vector<std::shared_ptr<cudf::packed_columns>> dataToBroadcast_;
+
+  // For arbitrary: shared pool of data that any consumer can pull from.
+  std::deque<std::shared_ptr<cudf::packed_columns>> arbitraryBuffer_;
+
+  // For arbitrary: round-robin index for distributing data to waiting
+  // consumers.
+  int32_t nextArbitraryLoadIndex_{0};
 
   /// If 'queuedBytes_' > 'maxSize_', each producer is blocked after adding
   /// data.

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -1476,6 +1476,76 @@ TEST_P(UcxExchangeTest, deferredRequestCleanupOnTaskAbort) {
   config.intraNodeExchange = origIntraNode;
 }
 
+// Arbitrary exchange: data distributed (not duplicated) across consumers.
+TEST_P(UcxExchangeTest, arbitraryExchange) {
+  {
+    ExchangeTestParams p = GetParam();
+    if (p.numSrcDrivers != 1 || p.numDstDrivers != 1 || p.numPartitions != 1 ||
+        p.numChunks != 100 || p.numUpstreamTasks != 1 ||
+        p.tableType != TableType::NARROW) {
+      GTEST_SKIP() << "arbitraryExchange: runs only once";
+    }
+  }
+
+  const std::string taskPrefix = getUniqueTaskPrefix();
+  const std::string srcTaskId = taskPrefix + "arbitrarySrc";
+  const int numDestinations = 3;
+  const int numDrivers = 1;
+  const int numChunks = 10;
+  const int numRowsPerChunk = 1'000;
+
+  auto srcTask = createSourceTask(srcTaskId, pool_, UcxTestData::kTestRowType);
+  queueManager_->initializeTask(
+      srcTask,
+      core::PartitionedOutputNode::Kind::kArbitrary,
+      numDestinations,
+      numDrivers);
+  queueManager_->updateOutputBuffers(srcTaskId, numDestinations, true);
+
+  std::vector<std::shared_ptr<SinkDriverMock>> sinkDrivers;
+  for (int destId = 0; destId < numDestinations; ++destId) {
+    const std::string sinkTaskId =
+        taskPrefix + "arbitrarySink" + std::to_string(destId);
+    core::PlanNodeId exchangeNodeId;
+    auto sinkTask = createExchangeTask(
+        sinkTaskId, UcxTestData::kTestRowType, destId, exchangeNodeId);
+    auto sinkDriver =
+        std::make_shared<SinkDriverMock>(sinkTask, /*numDrivers=*/1);
+
+    std::vector<exec::Split> splits;
+    splits.emplace_back(remoteSplit(srcTaskId, destId));
+    sinkDriver->addSplits(splits);
+
+    sinkDrivers.push_back(sinkDriver);
+  }
+
+  // Arbitrary sends all to destination 0 (numPartitions=1).
+  auto sourceMock = std::make_shared<UcxPartitionedOutputMock>(
+      srcTaskId, numDrivers, /*numPartitions=*/1, numChunks, numRowsPerChunk);
+
+  sourceMock->run();
+  for (auto& sink : sinkDrivers) {
+    sink->run();
+  }
+
+  sourceMock->joinThreads();
+  for (auto& sink : sinkDrivers) {
+    sink->joinThreads();
+  }
+
+  // Total rows distributed across sinks must equal total produced.
+  const size_t expectedTotalRows =
+      static_cast<size_t>(numChunks) * numRowsPerChunk;
+  size_t totalRows = 0;
+  for (int i = 0; i < numDestinations; ++i) {
+    totalRows += sinkDrivers[i]->numRows();
+  }
+  EXPECT_EQ(totalRows, expectedTotalRows)
+      << "Total rows across all sinks should equal total produced";
+
+  queueManager_->removeTask(srcTaskId);
+}
+
 std::shared_ptr<UcxOutputQueueManager> UcxExchangeTest::queueManager_;
 std::shared_ptr<std::thread> UcxExchangeTest::communicatorThread_;
 std::shared_ptr<Communicator> UcxExchangeTest::communicator_;

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -749,8 +749,10 @@ TEST_F(UcxOutputQueueManagerTest, arbitraryLateDestination) {
   queueManager_->removeTask(taskId);
 }
 
-// Arbitrary: isFinished requires noMoreQueues signal.
-TEST_F(UcxOutputQueueManagerTest, arbitraryNotFinishedWithoutNoMoreQueues) {
+// Arbitrary: isFinished does not require noMoreQueues — once all destination
+// queues are consumed (null), it is finished. This matches
+// OutputBuffer::isFinishedLocked() which only gates broadcast on noMoreBuffers.
+TEST_F(UcxOutputQueueManagerTest, arbitraryFinishedWithoutNoMoreQueues) {
   const std::string taskId = "arbitrary2";
 
   auto task = initializeTask(
@@ -764,14 +766,12 @@ TEST_F(UcxOutputQueueManagerTest, arbitraryNotFinishedWithoutNoMoreQueues) {
 
   noMoreData(taskId);
 
+  // Not finished: destination 1 has not consumed its end marker yet.
   fetchEndMarker(taskId, 0);
-  fetchEndMarker(taskId, 1);
-
-  // Not finished because noMoreQueues hasn't been signaled.
   EXPECT_FALSE(queueManager_->isFinished(taskId));
 
-  queueManager_->updateOutputBuffers(taskId, 2, true);
-
+  // Once all destinations have consumed, finished — even without noMoreQueues.
+  fetchEndMarker(taskId, 1);
   EXPECT_TRUE(queueManager_->isFinished(taskId));
   queueManager_->removeTask(taskId);
 }

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -670,3 +670,278 @@ TEST_F(UcxOutputQueueManagerTest, broadcastEndMarkerToLateDestination) {
   EXPECT_TRUE(queueManager_->isFinished(taskId));
   queueManager_->removeTask(taskId);
 }
+
+// --- Arbitrary tests ---
+
+// Basic arbitrary: enqueue data, consumers pull from shared pool (no
+// duplication). Each batch goes to exactly one consumer.
+TEST_F(UcxOutputQueueManagerTest, arbitraryBasic) {
+  const vector_size_t size = 100;
+  const std::string taskId = "arbitrary0";
+  const int numDestinations = 3;
+
+  auto task = initializeTask(
+      taskId,
+      1 /* numDestinations (plan node uses 1) */,
+      1 /* numDrivers */,
+      true /* cleanup */,
+      core::PartitionedOutputNode::Kind::kArbitrary);
+
+  EXPECT_FALSE(queueManager_->isFinished(taskId));
+
+  // Grow to the actual number of consumers.
+  queueManager_->updateOutputBuffers(taskId, numDestinations, true);
+
+  // Enqueue 3 batches (all to destination 0, as the operator does).
+  enqueue(taskId, 0, size);
+  enqueue(taskId, 0, size);
+  enqueue(taskId, 0, size);
+
+  // Each consumer gets exactly one batch.
+  for (int dest = 0; dest < numDestinations; ++dest) {
+    fetch(taskId, dest);
+  }
+
+  noMoreData(taskId);
+
+  for (int dest = 0; dest < numDestinations; ++dest) {
+    fetchEndMarker(taskId, dest);
+  }
+
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
+// Arbitrary: late destination receives only future data, no backfill.
+TEST_F(UcxOutputQueueManagerTest, arbitraryLateDestination) {
+  const vector_size_t size = 50;
+  const std::string taskId = "arbitrary1";
+
+  auto task = initializeTask(
+      taskId,
+      1 /* numDestinations */,
+      1 /* numDrivers */,
+      true /* cleanup */,
+      core::PartitionedOutputNode::Kind::kArbitrary);
+
+  // Enqueue 2 batches before a second consumer arrives.
+  enqueue(taskId, 0, size);
+  enqueue(taskId, 0, size);
+
+  // Destination 0 consumes both batches.
+  fetch(taskId, 0);
+  fetch(taskId, 0);
+
+  // Add a late destination. It gets NO backfill (unlike broadcast).
+  queueManager_->updateOutputBuffers(taskId, 2, false);
+
+  // Enqueue 1 more batch — the late consumer should get it.
+  enqueue(taskId, 0, size);
+  fetch(taskId, 1);
+
+  queueManager_->updateOutputBuffers(taskId, 2, true);
+  noMoreData(taskId);
+
+  fetchEndMarker(taskId, 0);
+  fetchEndMarker(taskId, 1);
+
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
+// Arbitrary: isFinished requires noMoreQueues signal.
+TEST_F(UcxOutputQueueManagerTest, arbitraryNotFinishedWithoutNoMoreQueues) {
+  const std::string taskId = "arbitrary2";
+
+  auto task = initializeTask(
+      taskId,
+      1 /* numDestinations */,
+      1 /* numDrivers */,
+      true /* cleanup */,
+      core::PartitionedOutputNode::Kind::kArbitrary);
+
+  queueManager_->updateOutputBuffers(taskId, 2, false);
+
+  noMoreData(taskId);
+
+  fetchEndMarker(taskId, 0);
+  fetchEndMarker(taskId, 1);
+
+  // Not finished because noMoreQueues hasn't been signaled.
+  EXPECT_FALSE(queueManager_->isFinished(taskId));
+
+  queueManager_->updateOutputBuffers(taskId, 2, true);
+
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
+// Arbitrary: concurrent multi-fetcher stress test. Total consumed must equal
+// total produced; individual consumer counts may vary (demand-driven).
+TEST_F(UcxOutputQueueManagerTest, arbitraryMultiFetchers) {
+  const vector_size_t size = 10;
+  const std::string taskId = "arbitrary3";
+  const int numDestinations = 5;
+
+  initializeTask(
+      taskId,
+      1 /* numDestinations */,
+      1 /* numDrivers */,
+      true /* cleanup */,
+      core::PartitionedOutputNode::Kind::kArbitrary);
+
+  queueManager_->updateOutputBuffers(taskId, numDestinations, true);
+
+  std::vector<std::thread> threads;
+  std::vector<int64_t> fetchedPackedColumns(numDestinations, 0);
+
+  for (int i = 0; i < numDestinations; ++i) {
+    threads.emplace_back([&, i]() {
+      dataFetcher(
+          taskId, i, fetchedPackedColumns.at(i), false /* earlyTermination */);
+    });
+  }
+
+  const int totalPackedColumns = 100;
+  for (int i = 0; i < totalPackedColumns; ++i) {
+    enqueue(taskId, 0, size);
+    if (folly::Random().oneIn(4)) {
+      std::this_thread::sleep_for(std::chrono::microseconds(5)); // NOLINT
+    }
+  }
+  noMoreData(taskId);
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  int64_t totalFetched = 0;
+  for (int i = 0; i < numDestinations; ++i) {
+    totalFetched += fetchedPackedColumns[i];
+  }
+  ASSERT_EQ(totalFetched, totalPackedColumns);
+
+  queueManager_->removeTask(taskId);
+}
+
+// All consumers delete before drain: the checkIfDone drain must not loop
+// infinitely when every destination queue has been deleted.
+TEST_F(UcxOutputQueueManagerTest, arbitraryAllDeletedBeforeDrain) {
+  const vector_size_t size = 10;
+  const std::string taskId = "arbitrary4";
+
+  auto task = initializeTask(
+      taskId,
+      1 /* numDestinations */,
+      1 /* numDrivers */,
+      true /* cleanup */,
+      core::PartitionedOutputNode::Kind::kArbitrary);
+
+  queueManager_->updateOutputBuffers(taskId, 3, true);
+
+  // Enqueue batches — they sit in the shared arbitrary buffer.
+  enqueue(taskId, 0, size);
+  enqueue(taskId, 0, size);
+  enqueue(taskId, 0, size);
+
+  // Delete all destination queues before any data is consumed.
+  deleteResults(taskId, 0);
+  deleteResults(taskId, 1);
+  deleteResults(taskId, 2);
+
+  // noMoreData triggers checkIfDone which drains the arbitrary buffer.
+  // Must not hang.
+  noMoreData(taskId);
+
+  EXPECT_TRUE(queueManager_->isFinished(taskId));
+  queueManager_->removeTask(taskId);
+}
+
+// Terminate with data in arbitraryBuffer: pending callbacks must fire with
+// nullptr and the queue must not leak or hang.
+TEST_F(UcxOutputQueueManagerTest, arbitraryTerminateWithBufferedData) {
+  const vector_size_t size = 10;
+  const std::string taskId = "arbitrary5";
+
+  auto task = initializeTask(
+      taskId,
+      1 /* numDestinations */,
+      1 /* numDrivers */,
+      true /* cleanup */,
+      core::PartitionedOutputNode::Kind::kArbitrary);
+
+  queueManager_->updateOutputBuffers(taskId, 2, true);
+
+  // Enqueue data that sits in the shared pool.
+  enqueue(taskId, 0, size);
+  enqueue(taskId, 0, size);
+
+  // Register callbacks on both destinations (consumers waiting for data).
+  bool callback0Fired = false;
+  bool callback0Nullptr = false;
+  bool callback1Fired = false;
+  bool callback1Nullptr = false;
+
+  // Destination 0 should get data immediately from the arbitrary buffer.
+  queueManager_->getData(
+      taskId,
+      0,
+      [&callback0Fired, &callback0Nullptr](
+          std::shared_ptr<cudf::packed_columns> data,
+          std::vector<int64_t> /*remainingBytes*/) {
+        callback0Fired = true;
+        callback0Nullptr = (data == nullptr);
+      });
+  EXPECT_TRUE(callback0Fired);
+  EXPECT_FALSE(callback0Nullptr);
+
+  // Destination 1 should also get data immediately.
+  queueManager_->getData(
+      taskId,
+      1,
+      [&callback1Fired, &callback1Nullptr](
+          std::shared_ptr<cudf::packed_columns> data,
+          std::vector<int64_t> /*remainingBytes*/) {
+        callback1Fired = true;
+        callback1Nullptr = (data == nullptr);
+      });
+  EXPECT_TRUE(callback1Fired);
+  EXPECT_FALSE(callback1Nullptr);
+
+  // Enqueue more data, then register callbacks that will be pending.
+  enqueue(taskId, 0, size);
+  callback0Fired = false;
+  callback1Fired = false;
+  queueManager_->getData(
+      taskId,
+      0,
+      [&callback0Fired, &callback0Nullptr](
+          std::shared_ptr<cudf::packed_columns> data,
+          std::vector<int64_t> /*remainingBytes*/) {
+        callback0Fired = true;
+        callback0Nullptr = (data == nullptr);
+      });
+  // Destination 0 should get the data immediately.
+  EXPECT_TRUE(callback0Fired);
+  EXPECT_FALSE(callback0Nullptr);
+
+  // Destination 1 has no data — callback is installed but pending.
+  queueManager_->getData(
+      taskId,
+      1,
+      [&callback1Fired, &callback1Nullptr](
+          std::shared_ptr<cudf::packed_columns> data,
+          std::vector<int64_t> /*remainingBytes*/) {
+        callback1Fired = true;
+        callback1Nullptr = (data == nullptr);
+      });
+  EXPECT_FALSE(callback1Fired);
+
+  // Simulate task failure: abort then remove (which calls terminate).
+  task->requestAbort().wait();
+  queueManager_->removeTask(taskId);
+
+  // Pending callback must have fired with nullptr (end-of-stream).
+  EXPECT_TRUE(callback1Fired);
+  EXPECT_TRUE(callback1Nullptr);
+}


### PR DESCRIPTION
## Summary

Add support for ARBITRARY partitioned output in the UCX exchange path, matching the semantics of OutputBuffer's arbitrary mode.

- Add `arbitraryBuffer_` shared pool and round-robin distribution in `UcxOutputQueue`, mirroring OutputBuffer's `ArbitraryBuffer`.
- Add `enqueueArbitraryOutputLocked()` for demand-driven distribution to destinations with waiting consumers.
- Add arbitrary pull from shared buffer in `getData()` when destination queue is empty.
- Drain remaining arbitrary buffer round-robin in `checkIfDone()` before sending end markers.
- Allow `kArbitrary` in `updateOutputBuffers()` alongside `kBroadcast`, with no backfill for new arbitrary consumers (only future data).
- Fix `isFinishedLocked()` to only gate on `noMoreQueues_` for `kBroadcast`, not `kArbitrary`. The standard `OutputBuffer::isFinishedLocked()` does not gate arbitrary on `noMoreBuffers_` because the coordinator lazily manages arbitrary consumers and may never send `noMoreBufferIds`.
- Clear `arbitraryBuffer_` in `terminate()`.
- Add `UcxOutputQueueManagerTest` for arbitrary enqueue, getData, and round-robin distribution.
- Add `UcxExchangeTest` end-to-end test for arbitrary exchange.
- Fix test to match corrected `isFinishedLocked()` behavior where `kArbitrary` no longer gates on `noMoreQueues_`.

## Known gap

`cudfPartitionedOutput` does not call `noMoreData()` on the standard `OutputBufferManager`, leaving it in an incomplete state (`atEnd_=false`, `totalRowsSent=0`). This does not affect correctness since task completion is driven by the UCX path, but the coordinator sees inconsistent buffer metrics for UCX tasks.

## Test plan

- [x] Unit tests: `UcxOutputQueueManagerTest` for arbitrary enqueue, getData, and round-robin distribution
- [x] End-to-end test: `UcxExchangeTest` for arbitrary exchange
- [x] Regression test: `arbitraryNotFinishedWithoutNoMoreQueues` updated to verify correct semantics